### PR TITLE
fix: avoid yaml load error when creating helm values

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.15.34",
     "@types/uuid": "^10.0.0",
+    "eslint": "^9.15.0",
     "husky": "^9.1.7",
     "nodemon": "^3.1.10",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      eslint:
+        specifier: ^9.15.0
+        version: 9.30.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/src/observability-repo-manager.ts
+++ b/src/observability-repo-manager.ts
@@ -50,16 +50,20 @@ export interface ObservabilityProject {
 
 interface ObservabilityData {
   global: {
-    projects: {
+    tenants?: {
+      [x: string]: Tenant
+    }
+    projects?: {
       [x: string]: ObservabilityProject
     }
   }
 }
 
-const yamlInitData = `
-  global:
-    tenants: []
-  `
+const yamlInitData: ObservabilityData = {
+  global: {
+    tenants: {},
+  },
+}
 
 export class ObservabilityRepoManager {
   private gitlabApi: IGitlab
@@ -165,7 +169,7 @@ export class ObservabilityRepoManager {
 
     // Récupérer le fichier values.yaml
     const yamlFile = await this.getValuesFile(gitlabRepo)
-      || yaml.load(Buffer.from(yamlInitData, 'base64').toString('utf-8')) as ObservabilityData
+      || yamlInitData
 
     const projects = yamlFile.global?.projects || {}
 


### PR DESCRIPTION
Si le fichier n'existe pas dans le dépôt `observability`, il semble que ça fasse planter le plugin.

Correction en n'ayant qu'un seul `yaml.load` qui nous permettra de valider cette hypothèse, tout en rendant le code typesafe