### PR TITLE
refactor: :recycle: rename getRepoUrl function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cpn-console/observability-plugin",
   "type": "module",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Observability plugin for DSO console",
   "exports": {
     ".": {

--- a/src/function.ts
+++ b/src/function.ts
@@ -95,7 +95,7 @@ export const upsertProject: StepCall<Project> = async (payload) => {
     const projectValue: ObservabilityProject = {
       projectName: project.slug,
       projectRepository: {
-        url: await gitlabApi.getRepoUrl(observabilityRepository),
+        url: await gitlabApi.getPublicRepoUrl(observabilityRepository),
         path: '.',
       },
       envs: {


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
With https://github.com/cloud-pi-native/console/pull/1791, we will face `message":"gitlabApi.getRepoUrl is not a function"`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Rename the function appropriately.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Yes, will need to change credentials url form public to internal on the Exploit Argocd.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No.